### PR TITLE
Added adaptation for Compose Multiplatform 1.5.0-beta01

### DIFF
--- a/library/calendar-compose-pager/src/commonMain/kotlin/epicarchitect/calendar/compose/pager/EpicCalendarPager.kt
+++ b/library/calendar-compose-pager/src/commonMain/kotlin/epicarchitect/calendar/compose/pager/EpicCalendarPager.kt
@@ -41,11 +41,8 @@ fun EpicCalendarPager(
         HorizontalPager(
             modifier = modifier,
             state = state.pagerState,
-            pageCount = remember(state.monthRange) {
-                state.monthRange.size()
-            },
             verticalAlignment = Alignment.Top
-        ) { page ->
+        ){ page ->
             BasisEpicCalendar(
                 modifier = pageModifier(page),
                 state = rememberBasisEpicCalendarState(

--- a/library/calendar-compose-pager/src/commonMain/kotlin/epicarchitect/calendar/compose/pager/state/MutableState.kt
+++ b/library/calendar-compose-pager/src/commonMain/kotlin/epicarchitect/calendar/compose/pager/state/MutableState.kt
@@ -13,6 +13,7 @@ import epicarchitect.calendar.compose.basis.addMonths
 import epicarchitect.calendar.compose.basis.addYears
 import epicarchitect.calendar.compose.basis.getByIndex
 import epicarchitect.calendar.compose.basis.indexOf
+import epicarchitect.calendar.compose.basis.size
 import epicarchitect.calendar.compose.pager.config.EpicCalendarPagerConfig
 import epicarchitect.calendar.compose.pager.config.LocalEpicCalendarPagerConfig
 
@@ -50,7 +51,9 @@ fun rememberEpicCalendarPagerState(
     val pagerState = rememberPagerState(
         initialPage = remember(monthRange, initialMonth) {
             monthRange.indexOf(initialMonth) ?: 0
-        }
+        },
+        initialPageOffsetFraction = 0f,
+        pageCount = {monthRange.size()}
     )
 
     return remember(

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,6 +1,6 @@
 [libraries]
 android-gradlePlugin = "com.android.tools.build:gradle:8.0.0"
 kotlin-gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20"
-compose-gradlePlugin = "org.jetbrains.compose:compose-gradle-plugin:1.4.0"
+compose-gradlePlugin = "org.jetbrains.compose:compose-gradle-plugin:1.5.0-beta01"
 kotlin-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
 android-activityCompose = "androidx.activity:activity-compose:1.7.1"


### PR DESCRIPTION
Project need update for Compose Multiplatform 1.5.0-beta01, because HorizontalPager with pageCount was deprecated in this version.